### PR TITLE
Breaking: replaced `:include_expired` and `:only_expired` in query filters with `:status` 

### DIFF
--- a/demo/lib/ecto_sessions_demo_web/controllers/page_controller.ex
+++ b/demo/lib/ecto_sessions_demo_web/controllers/page_controller.ex
@@ -129,7 +129,7 @@ defmodule EctoSessionsDemoWeb.PageController do
     case Sessions.get_session(
            id: session_id,
            user_id: user.id,
-           include_expired: true
+           status: :all
          ) do
       nil ->
         conn
@@ -196,7 +196,7 @@ defmodule EctoSessionsDemoWeb.PageController do
     sessions =
       Sessions.list_sessions(
         user_id: current_user.id,
-        include_expired: true
+        status: :all
       )
 
     render(

--- a/demo/lib/ecto_sessions_demo_web/controllers/page_controller.ex
+++ b/demo/lib/ecto_sessions_demo_web/controllers/page_controller.ex
@@ -206,4 +206,14 @@ defmodule EctoSessionsDemoWeb.PageController do
       auth_token: Map.get(conn.req_cookies, @auth_token_cookie_name)
     )
   end
+
+  def stats(conn, _) do
+    render(
+      conn,
+      "stats.html",
+      total_session_count: Sessions.count(status: :all),
+      active_session_count: Sessions.count(status: :valid),
+      expired_session_count: Sessions.count(status: :expired)
+    )
+  end
 end

--- a/demo/lib/ecto_sessions_demo_web/router.ex
+++ b/demo/lib/ecto_sessions_demo_web/router.ex
@@ -24,6 +24,8 @@ defmodule EctoSessionsDemoWeb.Router do
     get("/", PageController, :index)
     post("/login", PageController, :login)
     post("/signup", PageController, :signup)
+
+    get("/stats", PageController, :stats)
   end
 
   scope "/", EctoSessionsDemoWeb do

--- a/demo/lib/ecto_sessions_demo_web/templates/page/index.html.heex
+++ b/demo/lib/ecto_sessions_demo_web/templates/page/index.html.heex
@@ -17,17 +17,6 @@
       <%= submit "Create user" %>
     <% end %>
 
-    <%# <ul>
-      <li>
-        <a href="https://hexdocs.pm/phoenix/overview.html">Create an account</a>
-      </li>
-      <li>
-        <a href="https://github.com/phoenixframework/phoenix"></a>
-      </li>
-      <li>
-        <a href="https://github.com/phoenixframework/phoenix/blob/v1.6/CHANGELOG.md">v1.6 Changelog</a>
-      </li>
-    </ul> %>
   </article>
   <article class="column">
     <h2>Login</h2>

--- a/demo/lib/ecto_sessions_demo_web/templates/page/stats.html.heex
+++ b/demo/lib/ecto_sessions_demo_web/templates/page/stats.html.heex
@@ -1,0 +1,12 @@
+<section>
+  <h1>Server stats</h1>
+
+  <dl>
+    <dt>Total session count</dt>
+    <dd><%= @total_session_count %> </dd>
+    <dt>Active session count</dt>
+    <dd><%= @active_session_count %> </dd>
+    <dt>Expired session count</dt>
+    <dd><%= @expired_session_count %> </dd>
+  </dl>
+</section>

--- a/lib/ecto_sessions.ex
+++ b/lib/ecto_sessions.ex
@@ -197,6 +197,19 @@ defmodule EctoSessions do
       def update_session!(changeset) do
         @repo.update!(changeset)
       end
+
+      def count(filters \\ [], options \\ []) do
+        get_sessions_query(filters, options)
+        |> @repo.aggregate(:count, prefix: unquote(prefix))
+      end
+
+      def delete_expired() do
+        {delete_count, _} =
+          get_sessions_query([status: :expired], delete_query: true)
+          |> @repo.delete_all(prefix: unquote(prefix))
+
+        delete_count
+      end
     end
   end
 
@@ -204,7 +217,7 @@ defmodule EctoSessions do
   Creates a session. `attrs` is a map that contains `EctoSessions.Session` attributes,
   where the keys are atoms.
 
-  Uses `Ecto.Repo.insert/2`
+  Uses `Ecto.Repo.insert`
 
   ## Examples
 
@@ -221,7 +234,7 @@ defmodule EctoSessions do
   @callback create_session(attrs :: map) :: Ecto.Schema.t()
 
   @doc """
-  Same as `create_session/1` but using `Ecto.Repo.insert!/2`.
+  Same as `create_session/1` but using `Ecto.Repo.insert!`.
   """
   @callback create_session!(filters :: map, options :: list) :: Ecto.Schema.t()
 
@@ -285,5 +298,15 @@ defmodule EctoSessions do
   @doc """
   Updates a session using `Repo.update!`.
   """
-  @callback delete_session!(Ecto.Changeset.t()) :: Ecto.Schema.t()
+  @callback update_session!(Ecto.Changeset.t()) :: Ecto.Schema.t()
+
+  @doc """
+  Count the sessions matching the provided filters.
+  """
+  @callback count(Ecto.Changeset.t()) :: Ecto.Schema.t()
+
+  @doc """
+  Deletes expired sessions.
+  """
+  @callback delete_expired(Ecto.Changeset.t()) :: Ecto.Schema.t()
 end

--- a/lib/ecto_sessions.ex
+++ b/lib/ecto_sessions.ex
@@ -90,7 +90,7 @@ defmodule EctoSessions do
       end
 
       def filter_session_query(query, filters) when is_list(filters) do
-        filters = Keyword.put_new(filters, :include_expired, false)
+        filters = Keyword.put_new(filters, :status, :valid)
 
         Enum.reduce(
           filters,
@@ -101,7 +101,9 @@ defmodule EctoSessions do
         )
       end
 
-      def filter_session_query_by(query, :include_expired, false) do
+      def filter_session_query_by(query, :status, :all), do: query
+
+      def filter_session_query_by(query, :status, :valid) do
         from(
           session in query,
           where:
@@ -110,18 +112,18 @@ defmodule EctoSessions do
         )
       end
 
-      def filter_session_query_by(query, :include_expired, true), do: query
-
-      def filter_session_query_by(query, :only_expired, true) do
+      def filter_session_query_by(query, :status, :expired) do
         from(
           session in query,
           where:
-            not is_nil(session.expires_at) or
+            not is_nil(session.expires_at) and
               session.expires_at <= ^DateTime.utc_now()
         )
       end
 
-      def filter_session_query_by(query, :only_expired, false), do: query
+      def filter_session_query_by(query, :status, status) do
+        raise RuntimeError, "Invalid status #{status}"
+      end
 
       def filter_session_query_by(query, :auth_token, nil) do
         from(session in query, where: false)


### PR DESCRIPTION
This is a breaking change. Note that `only_expired` did not work as intended.

Example with `status`:
```elixir
Sessions.count(status: :all)
Sessions.count(status: :valid)
Sessions.count(status: :expired)
```

To demo this added a new page `/stats` in the demo project.